### PR TITLE
added yamllint option

### DIFF
--- a/nac_validate/cli/main.py
+++ b/nac_validate/cli/main.py
@@ -9,7 +9,6 @@ from typing import Annotated
 
 import typer
 
-import nac_validate
 import nac_validate.validator
 
 from ..exceptions import (

--- a/nac_validate/cli/main.py
+++ b/nac_validate/cli/main.py
@@ -160,7 +160,9 @@ def main(
     configure_logging(verbosity)
 
     try:
-        validator = nac_validate.validator.Validator(schema, rules, enable_yamllint=yamllint_on)
+        validator = nac_validate.validator.Validator(
+            schema, rules, enable_yamllint=yamllint_on
+        )
         validator.validate_syntax(paths, not non_strict)
         validator.validate_semantics(paths)
         if output:

--- a/nac_validate/cli/main.py
+++ b/nac_validate/cli/main.py
@@ -9,6 +9,7 @@ from typing import Annotated
 
 import typer
 
+import nac_validate
 import nac_validate.validator
 
 from ..exceptions import (
@@ -123,6 +124,16 @@ NonStrict = Annotated[
 ]
 
 
+YamllintOn = Annotated[
+    bool,
+    typer.Option(
+        "--yamllint-on",
+        help="Enable yamllint validation.",
+        envvar="NAC_VALIDATE_YAMLLINT_ON",
+    ),
+]
+
+
 Version = Annotated[
     bool,
     typer.Option(
@@ -142,13 +153,14 @@ def main(
     rules: Rules = DEFAULT_RULES,
     output: Output = None,
     non_strict: NonStrict = False,
+    yamllint_on: YamllintOn = False,
     version: Version = False,
 ) -> None:
     """A CLI tool to perform syntactic and semantic validation of YAML files."""
     configure_logging(verbosity)
 
     try:
-        validator = nac_validate.validator.Validator(schema, rules)
+        validator = nac_validate.validator.Validator(schema, rules, enable_yamllint=yamllint_on)
         validator.validate_syntax(paths, not non_strict)
         validator.validate_semantics(paths)
         if output:

--- a/nac_validate/cli/main.py
+++ b/nac_validate/cli/main.py
@@ -123,12 +123,12 @@ NonStrict = Annotated[
 ]
 
 
-YamllintOn = Annotated[
+DisableYamllint = Annotated[
     bool,
     typer.Option(
-        "--yamllint-on",
-        help="Enable yamllint validation.",
-        envvar="NAC_VALIDATE_YAMLLINT_ON",
+        "--disable-yamllint",
+        help="Disable yamllint validation.",
+        envvar="NAC_VALIDATE_DISABLE_YAMLLINT",
     ),
 ]
 
@@ -152,7 +152,7 @@ def main(
     rules: Rules = DEFAULT_RULES,
     output: Output = None,
     non_strict: NonStrict = False,
-    yamllint_on: YamllintOn = False,
+    disable_yamllint: DisableYamllint = False,
     version: Version = False,
 ) -> None:
     """A CLI tool to perform syntactic and semantic validation of YAML files."""
@@ -160,7 +160,7 @@ def main(
 
     try:
         validator = nac_validate.validator.Validator(
-            schema, rules, enable_yamllint=yamllint_on
+            schema, rules, enable_yamllint=not disable_yamllint
         )
         validator.validate_syntax(paths, not non_strict)
         validator.validate_semantics(paths)

--- a/nac_validate/validator.py
+++ b/nac_validate/validator.py
@@ -81,7 +81,7 @@ class Validator:
         logger.debug(f"Running yamllint on {file_path}")
         
         try:
-            # NAC-specific yamllint configuration - only new-lines rule enabled
+            # NAC-specific yamllint configuration - only minimum checks and new-lines rule enabled
             config = "{extends: relaxed, rules: {new-lines: enable}}"
             
             result = subprocess.run(
@@ -113,7 +113,7 @@ class Validator:
         if os.path.isfile(file_path) and file_path.suffix in [".yaml", ".yml"]:
             logger.info("Validate file: %s", file_path)
 
-            # YAML syntax validation first
+            # YAML syntax validation
             data = None
             try:
                 data = load_yaml_files([file_path])

--- a/nac_validate/validator.py
+++ b/nac_validate/validator.py
@@ -5,7 +5,7 @@ import importlib
 import importlib.util
 import logging
 import os
-import subprocess
+import subprocess  # nosec B404
 import sys
 import warnings
 from inspect import signature
@@ -86,7 +86,7 @@ class Validator:
             # NAC-specific yamllint configuration - minimal validation with only new-lines and anchors
             config = "{extends: relaxed, rules: {key-duplicates: disable, new-line-at-end-of-file: disable, hyphens: disable, indentation: disable, colons: disable, commas: disable, empty-lines: disable, line-length: disable, trailing-spaces: {level: warning}, new-lines: enable}}"
 
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603 B607
                 ["yamllint", "-d", config, str(file_path)],
                 capture_output=True,
                 text=True,

--- a/nac_validate/validator.py
+++ b/nac_validate/validator.py
@@ -81,8 +81,8 @@ class Validator:
         logger.debug(f"Running yamllint on {file_path}")
         
         try:
-            # NAC-specific yamllint configuration - only minimum checks and new-lines rule enabled
-            config = "{extends: relaxed, rules: {new-lines: enable}}"
+            # NAC-specific yamllint configuration - minimal validation with only new-lines and anchors
+            config = "{extends: relaxed, rules: {key-duplicates: disable, new-line-at-end-of-file: disable, hyphens: disable, indentation: disable, colons: disable, commas: disable, empty-lines: disable, line-length: disable, trailing-spaces: {level: warning}, new-lines: enable}}"
             
             result = subprocess.run(
                 ["yamllint", "-d", config, str(file_path)],

--- a/nac_validate/validator.py
+++ b/nac_validate/validator.py
@@ -84,7 +84,7 @@ class Validator:
 
         try:
             # NAC-specific yamllint configuration - minimal validation with only new-lines and anchors
-            config = "{extends: relaxed, rules: {key-duplicates: disable, new-line-at-end-of-file: disable, hyphens: disable, indentation: disable, colons: disable, commas: disable, empty-lines: disable, line-length: disable, trailing-spaces: {level: warning}, new-lines: enable}}"
+            config = "{extends: relaxed, rules: {key-duplicates: disable, new-line-at-end-of-file: disable, hyphens: disable, indentation: disable, colons: disable, commas: disable, empty-lines: disable, line-length: disable, trailing-spaces: disable, new-lines: enable}}"
 
             result = subprocess.run(  # nosec B603 B607
                 ["yamllint", "-d", config, str(file_path)],

--- a/nac_validate/validator.py
+++ b/nac_validate/validator.py
@@ -30,7 +30,9 @@ logger = logging.getLogger(__name__)
 
 
 class Validator:
-    def __init__(self, schema_path: Path, rules_path: Path, enable_yamllint: bool = False):
+    def __init__(
+        self, schema_path: Path, rules_path: Path, enable_yamllint: bool = False
+    ):
         self.enable_yamllint = enable_yamllint
         self.data: dict[str, Any] | None = None
         self.schema = None
@@ -75,34 +77,34 @@ class Validator:
 
     def _run_yamllint(self, file_path: Path) -> None:
         """Run yamllint validation on a file"""
-        if not file_path.suffix in [".yaml", ".yml"]:
+        if file_path.suffix not in [".yaml", ".yml"]:
             return
-            
+
         logger.debug(f"Running yamllint on {file_path}")
-        
+
         try:
             # NAC-specific yamllint configuration - minimal validation with only new-lines and anchors
             config = "{extends: relaxed, rules: {key-duplicates: disable, new-line-at-end-of-file: disable, hyphens: disable, indentation: disable, colons: disable, commas: disable, empty-lines: disable, line-length: disable, trailing-spaces: {level: warning}, new-lines: enable}}"
-            
+
             result = subprocess.run(
                 ["yamllint", "-d", config, str(file_path)],
                 capture_output=True,
-                text=True
+                text=True,
             )
-            
+
             logger.debug(f"Yamllint exit code: {result.returncode}")
-            
+
             if result.returncode != 0:
                 # Parse yamllint output - log errors but don't block other validations
-                for line in result.stdout.strip().split('\n'):
-                    if line.strip() and ':' in line:
+                for line in result.stdout.strip().split("\n"):
+                    if line.strip() and ":" in line:
                         # Extract filename and error details
                         if file_path.name in line:
                             continue  # Skip filename line
                         msg = f"Yamllint error: {line.strip()}"
                         logger.error(msg)
                         # Note: NOT adding to self.errors to allow other validations to continue
-                        
+
         except FileNotFoundError:
             logger.warning("yamllint not found - skipping yamllint validation")
         except Exception as e:

--- a/nac_validate/validator.py
+++ b/nac_validate/validator.py
@@ -5,7 +5,6 @@ import importlib
 import importlib.util
 import logging
 import os
-import subprocess  # nosec B404
 import sys
 import warnings
 from inspect import signature
@@ -13,6 +12,8 @@ from pathlib import Path
 from typing import Any
 
 import yamale
+import yamllint.config
+import yamllint.linter
 from nac_yaml.yaml import load_yaml_files, write_yaml_file
 from ruamel import yaml
 from yamale.yamale_error import YamaleError
@@ -83,30 +84,28 @@ class Validator:
         logger.debug(f"Running yamllint on {file_path}")
 
         try:
-            # NAC-specific yamllint configuration - minimal validation with only new-lines and anchors
-            config = "{extends: relaxed, rules: {key-duplicates: disable, new-line-at-end-of-file: disable, hyphens: disable, indentation: disable, colons: disable, commas: disable, empty-lines: disable, line-length: disable, trailing-spaces: disable, new-lines: enable}}"
+            # NAC-specific yamllint configuration - only new-lines validation enabled
+            config_str = "{extends: default, rules: {anchors: disable, braces: disable, brackets: disable, colons: disable, commas: disable, comments: disable, comments-indentation: disable, document-end: disable, document-start: disable, empty-lines: disable, empty-values: disable, float-values: disable, hyphens: disable, indentation: disable, key-duplicates: disable, key-ordering: disable, line-length: disable, new-line-at-end-of-file: disable, new-lines: enable, octal-values: disable, quoted-strings: disable, trailing-spaces: disable, truthy: disable}}"
+            config = yamllint.config.YamlLintConfig(config_str)
 
-            result = subprocess.run(  # nosec B603 B607
-                ["yamllint", "-d", config, str(file_path)],
-                capture_output=True,
-                text=True,
-            )
+            # Read file as bytes to preserve original line endings
+            with open(file_path, "rb") as f:
+                content = f.read()
+            
+            problems = yamllint.linter.run(content, config, file_path)
+            problem_list = list(problems)
 
-            logger.debug(f"Yamllint exit code: {result.returncode}")
+            logger.debug(f"Yamllint found {len(problem_list)} problems")
 
-            if result.returncode != 0:
-                # Parse yamllint output - log errors but don't block other validations
-                for line in result.stdout.strip().split("\n"):
-                    if line.strip() and ":" in line:
-                        # Extract filename and error details
-                        if file_path.name in line:
-                            continue  # Skip filename line
-                        msg = f"Yamllint error: {line.strip()}"
-                        logger.error(msg)
-                        # Note: NOT adding to self.errors to allow other validations to continue
+            if problem_list:
+                # Log yamllint problems but don't block other validations
+                for problem in problem_list:
+                    msg = f"Yamllint error: {file_path}:{problem.line}:{problem.column}: {problem.message} ({problem.rule})"
+                    logger.error(msg)
+                    # Note: NOT adding to self.errors to allow other validations to continue
 
-        except FileNotFoundError:
-            logger.warning("yamllint not found - skipping yamllint validation")
+        except ImportError:
+            logger.warning("yamllint not installed - skipping yamllint validation")
         except Exception as e:
             logger.warning(f"yamllint validation failed for {file_path}: {e}")
 

--- a/nac_validate/validator.py
+++ b/nac_validate/validator.py
@@ -91,7 +91,7 @@ class Validator:
             # Read file as bytes to preserve original line endings
             with open(file_path, "rb") as f:
                 content = f.read()
-            
+
             problems = yamllint.linter.run(content, config, file_path)
             problem_list = list(problems)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "typer>=0.17.4",
     "yamale>=6.0.0",
     "jmespath>=1.0.0",
+    "yamllint>=1.35.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "typer>=0.17.4",
     "yamale>=6.0.0",
     "jmespath>=1.0.0",
-    "yamllint>=1.35.1",
+    "yamllint>=1.38.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
added --yamllint_on parameter which checks following:

🔴 ERROR level rules:
new-lines - forces type of new line characters (unix/dos) <--------- fix for issue


- All other checks are disabled
- yamllint >= 1.38.0 is required
- by default yamllint is enabled
- you can disable yamllint with attribute --disable-yamllint
