### PR TITLE
feat: add JSON output format for both syntactic and semantic validation

### DIFF
--- a/nac_validate/cli/main.py
+++ b/nac_validate/cli/main.py
@@ -190,8 +190,13 @@ def main(
 
     except SyntaxValidationError as e:
         if format == OutputFormat.JSON:
+            # Omit None values from syntax errors (line/column not always available)
+            syntax_errors = [
+                {k: v for k, v in asdict(r).items() if v is not None}
+                for r in e.structured_results
+            ]
             json_output = {
-                "syntax_errors": [asdict(r) for r in e.structured_results],
+                "syntax_errors": syntax_errors,
                 "semantic_errors": [],
             }
             print(json.dumps(json_output, indent=2))

--- a/nac_validate/exceptions.py
+++ b/nac_validate/exceptions.py
@@ -3,6 +3,27 @@
 
 """Custom exceptions for nac-validate."""
 
+from dataclasses import dataclass
+
+
+@dataclass
+class SyntaxErrorResult:
+    """Structured syntax validation error."""
+
+    file: str
+    line: int | None
+    column: int | None
+    message: str
+
+
+@dataclass
+class SemanticErrorResult:
+    """Structured semantic validation error for a single rule."""
+
+    rule_id: str
+    description: str
+    errors: list[str]
+
 
 class ValidationError(Exception):
     """Base class for validation errors."""
@@ -35,14 +56,24 @@ class RuleLoadError(ValidationError):
 class SyntaxValidationError(ValidationError):
     """Raised when YAML syntax validation fails."""
 
-    def __init__(self, errors: list[str]):
+    def __init__(
+        self,
+        errors: list[str],
+        structured_results: list[SyntaxErrorResult] | None = None,
+    ):
         self.errors = errors
+        self.structured_results = structured_results or []
         super().__init__(f"Syntax validation failed with {len(errors)} error(s)")
 
 
 class SemanticValidationError(ValidationError):
     """Raised when semantic validation fails."""
 
-    def __init__(self, errors: list[str]):
+    def __init__(
+        self,
+        errors: list[str],
+        structured_results: list[SemanticErrorResult] | None = None,
+    ):
         self.errors = errors
+        self.structured_results = structured_results or []
         super().__init__(f"Semantic validation failed with {len(errors)} error(s)")

--- a/nac_validate/validator.py
+++ b/nac_validate/validator.py
@@ -176,9 +176,9 @@ class Validator:
 
         if len(results) > 0:
             for id, paths in results.items():
-                msg = (
-                    f"Semantic error, rule {id}: {self.rules[id].description} ({paths})"
-                )
+                header = f"Semantic error, rule {id}: {self.rules[id].description}:"
+                items = "\n".join(f"    - {path}" for path in paths)
+                msg = f"{header}\n{items}"
                 logger.error(msg)
                 semantic_errors.append(msg)
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -225,3 +225,22 @@ def test_merge(tmpdir: Path) -> None:
     )
     assert result.exit_code == 0
     assert filecmp.cmp(output_path, result_path, shallow=False)
+
+
+def test_semantic_error_output_format() -> None:
+    """Test that semantic errors are formatted as a human-readable bulleted list."""
+    runner = CliRunner()
+    input_path = "tests/integration/fixtures/data_semantic_error/"
+    rules_path = "tests/integration/fixtures/rules/"
+    result = runner.invoke(
+        nac_validate.cli.main.app,
+        ["-r", rules_path, "-v", "ERROR", input_path],
+    )
+    assert result.exit_code == 1
+    # Verify bulleted list format with 4-space indent
+    assert "    - " in result.output
+    # Verify header ends with colon (not parentheses with list)
+    assert "Semantic error, rule 101:" in result.output
+    # Verify no Python list representation in output
+    assert '["' not in result.output
+    assert "']" not in result.output

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 Daniel Schmidt
 
 import filecmp
+import json
 import os
 from pathlib import Path
 
@@ -244,3 +245,80 @@ def test_semantic_error_output_format() -> None:
     # Verify no Python list representation in output
     assert '["' not in result.output
     assert "']" not in result.output
+
+
+def test_json_format_success() -> None:
+    """Test JSON output format for successful validation."""
+    runner = CliRunner()
+    input_path = "tests/integration/fixtures/data/"
+    schema_path = "tests/integration/fixtures/schema/schema.yaml"
+    rules_path = "tests/integration/fixtures/rules/"
+    result = runner.invoke(
+        nac_validate.cli.main.app,
+        ["-s", schema_path, "-r", rules_path, "--format", "json", input_path],
+    )
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert output == {"syntax_errors": [], "semantic_errors": []}
+
+
+def test_json_format_semantic_errors() -> None:
+    """Test JSON output format for semantic validation errors."""
+    runner = CliRunner()
+    input_path = "tests/integration/fixtures/data_semantic_error/"
+    rules_path = "tests/integration/fixtures/rules/"
+    result = runner.invoke(
+        nac_validate.cli.main.app,
+        ["-r", rules_path, "--format", "json", input_path],
+    )
+    assert result.exit_code == 1
+    output = json.loads(result.output)
+    assert "syntax_errors" in output
+    assert "semantic_errors" in output
+    assert output["syntax_errors"] == []
+    assert len(output["semantic_errors"]) > 0
+    # Verify structure of semantic error
+    semantic_error = output["semantic_errors"][0]
+    assert "rule_id" in semantic_error
+    assert "description" in semantic_error
+    assert "errors" in semantic_error
+    assert isinstance(semantic_error["errors"], list)
+
+
+def test_json_format_syntax_errors() -> None:
+    """Test JSON output format for syntax validation errors."""
+    runner = CliRunner()
+    input_path = "tests/integration/fixtures/data_syntax_error/"
+    schema_path = "tests/integration/fixtures/schema/schema.yaml"
+    result = runner.invoke(
+        nac_validate.cli.main.app,
+        ["-s", schema_path, "--format", "json", input_path],
+    )
+    assert result.exit_code == 1
+    output = json.loads(result.output)
+    assert "syntax_errors" in output
+    assert "semantic_errors" in output
+    assert output["semantic_errors"] == []
+    assert len(output["syntax_errors"]) > 0
+    # Verify structure of syntax error
+    syntax_error = output["syntax_errors"][0]
+    assert "file" in syntax_error
+    assert "message" in syntax_error
+
+
+def test_json_format_no_logs_at_default_verbosity() -> None:
+    """Test that JSON mode suppresses logs at default verbosity."""
+    runner = CliRunner()
+    input_path = "tests/integration/fixtures/data_semantic_error/"
+    rules_path = "tests/integration/fixtures/rules/"
+    result = runner.invoke(
+        nac_validate.cli.main.app,
+        ["-r", rules_path, "--format", "json", input_path],
+    )
+    assert result.exit_code == 1
+    # Should be valid JSON without any log prefixes
+    output = json.loads(result.output)
+    assert "semantic_errors" in output
+    # Verify no ERROR or INFO prefixes in output
+    assert "ERROR - " not in result.output
+    assert "INFO - " not in result.output


### PR DESCRIPTION
> **Note:** This PR is stacked on #360 and should be merged after it.

## Summary

This PR adds a `--format json` CLI option for machine-parseable validation results.

## Usage

```bash
nac-validate -s /path/to/schema.yaml -r /path/to/rules --format json /path/to/data
```

## Output Structure

```
{
  "syntax_errors": [...],
  "semantic_errors": [...]
}
```

### Syntax Error Example (YAML parsing errors)

```json
{
  "syntax_errors": [
    {
      "file": "aac/data/tenant_chart2.nac.yaml",
      "line": 6,
      "column": 15,
      "message": "could not find expected ':'"
    }
  ],
  "semantic_errors": []
}
```

### Syntax Error Example (Schema validation errors)

```json
{
  "syntax_errors": [
    {
      "file": "aac/data/tenant_chart2.nac.yaml",
      "message": "apic.tenants.[name=chart2].filters.[name=chart2_test_ssh].entries.[naem=chart2_test_ssh_entry].naem: Unexpected element"
    },
    {
      "file": "aac/data/tenant_chart2.nac.yaml",
      "message": "apic.tenants.[name=chart2].filters.[name=chart2_test_ssh].entries.[naem=chart2_test_ssh_entry].name: Required field missing"
    },
    {
      "file": "aac/data/tenant_chart2.nac.yaml",
      "message": "apic.tenants.[name=chart2].filters.[name=chart2_test_http].entries.[name=chart2_test_http_entry].source_form_port: Unexpected element"
    }
  ],
  "semantic_errors": []
}
```

### Semantic Error Example

```json
{
  "syntax_errors": [],
  "semantic_errors": [
    {
      "rule_id": "311",
      "description": "Verify TCP or UDP protocol is specified for non-well-known ports in filters",
      "errors": [
        "apic.tenants[EXAMPLE].filters[BACKUP_PORTS].entries[TCP_8400] - Port fields contain non-well-known port(s) (destination_from_port=8400) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[BACKUP_PORTS].entries[TCP_8401] - Port fields contain non-well-known port(s) (destination_from_port=8401) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[BACKUP_PORTS].entries[TCP_8408] - Port fields contain non-well-known port(s) (destination_from_port=8408) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[BACKUP_PORTS].entries[TCP_2987] - Port fields contain non-well-known port(s) (destination_from_port=2987) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[BACKUP_PORTS].entries[TCP_8403] - Port fields contain non-well-known port(s) (destination_from_port=8403) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[BACKUP_PORTS].entries[TCP_8405] - Port fields contain non-well-known port(s) (destination_from_port=8405) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[SMB].entries[TCP_445] - Port fields contain non-well-known port(s) (destination_from_port=445) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[SMB-S].entries[TCP_445] - Port fields contain non-well-known port(s) (source_from_port=445) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[ESX_PORTS].entries[TCP_2049] - Port fields contain non-well-known port(s) (destination_from_port=2049) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[ESX_PORTS].entries[TCP_902] - Port fields contain non-well-known port(s) (destination_from_port=902) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[RDP-S].entries[TCP_3389] - Port fields contain non-well-known port(s) (source_from_port=3389) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[NetBIOS].entries[TCP_139] - Port fields contain non-well-known port(s) (destination_from_port=139) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[NetBIOS-S].entries[TCP_139] - Port fields contain non-well-known port(s) (source_from_port=445) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[EXAMPLE].filters[RDP].entries[RDP-TCP] - Port fields contain non-well-known port(s) (destination_from_port=3389) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[FILTER_TEST_FAIL].filters[CUSTOM_PORT_NO_PROTOCOL].entries[PORT_8080_NO_PROTO] - Port fields contain non-well-known port(s) (destination_from_port=8080) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[FILTER_TEST_FAIL].filters[SRC_CUSTOM_NO_PROTOCOL].entries[SRC_9000_NO_PROTO] - Port fields contain non-well-known port(s) (source_from_port=9000) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[FILTER_TEST_FAIL].filters[CUSTOM_PORT_ICMP].entries[ICMP_WITH_PORT] - Port fields contain non-well-known port(s) (destination_from_port=8080) but protocol is 'icmp' which is not valid for port-based filtering. Protocol must be 'tcp' or 'udp' when port fields are used.",
        "apic.tenants[FILTER_TEST_FAIL].filters[PORT_RANGE_NO_PROTOCOL].entries[RANGE_NO_PROTO] - Port fields contain non-well-known port(s) (destination_from_port=5000, destination_to_port=6000) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[FILTER_TEST_FAIL].filters[MIXED_PORTS_NO_PROTOCOL].entries[MIXED] - Port fields contain non-well-known port(s) (destination_from_port=9999) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers.",
        "apic.tenants[FILTER_TEST_FAIL].filters[BOTH_RULES_FAIL].entries[BAD_FILTER] - Port fields contain non-well-known port(s) (destination_to_port=5000) but protocol is 'igmp' which is not valid for port-based filtering. Protocol must be 'tcp' or 'udp' when port fields are used.",
        "apic.tenants[TEST].filters[PERMIT_TCP_81].entries[TCP-81] - Port fields contain non-well-known port(s) (destination_from_port=81) but protocol is not specified. Best practice dictates that protocol (tcp/udp) be explicitly defined when using non-well-known port numbers."
      ]
    },
    {
      "rule_id": "310",
      "description": "Verify filter port ranges are valid (to_port requires from_port, from <= to)",
      "errors": [
        "apic.tenants[FILTER_TEST_FAIL].filters[MISSING_DST_FROM_PORT].entries[TCP_TO_443] - destination_to_port is specified (443) but destination_from_port is missing. destination_from_port must be specified to define a valid port range.",
        "apic.tenants[FILTER_TEST_FAIL].filters[MISSING_SRC_FROM_PORT].entries[TCP_TO_8080] - source_to_port is specified (8080) but source_from_port is missing. source_from_port must be specified to define a valid port range.",
        "apic.tenants[FILTER_TEST_FAIL].filters[INVALID_DST_PORT_RANGE].entries[TCP_INVALID_RANGE] - destination_from_port (9000) is greater than destination_to_port (8000). From port must be less than or equal to to port.",
        "apic.tenants[FILTER_TEST_FAIL].filters[INVALID_SRC_PORT_RANGE].entries[TCP_INVALID_SRC_RANGE] - source_from_port (65535) is greater than source_to_port (1024). From port must be less than or equal to to port.",
        "apic.tenants[FILTER_TEST_FAIL].filters[BOTH_RULES_FAIL].entries[BAD_FILTER] - destination_to_port is specified (5000) but destination_from_port is missing. destination_from_port must be specified to define a valid port range.",
        "apic.tenants[chart2].filters[chart2_test_https].entries[chart2_test_https_entry] - destination_to_port is specified (https) but destination_from_port is missing. destination_from_port must be specified to define a valid port range.",
        "apic.tenants[chart2].filters[chart2_test_dns].entries[chart2_test_dns_entry] - source_to_port is specified (53) but source_from_port is missing. source_from_port must be specified to define a valid port range."
      ]
    }
  ]
}
```

## Notes

- Default format remains text (human-readable bulleted list)
- At default verbosity, JSON mode suppresses log messages to keep stdout clean (same as the human-readable text mode)
- Line/column fields only included for YAML parsing errors (not schema validation errors)
