### PR TITLE
Modification for how nac-validate handles python 3.14 warning messages.

### DIFF
--- a/nac_validate/validator.py
+++ b/nac_validate/validator.py
@@ -38,7 +38,7 @@ class Validator:
                 warnings.filterwarnings(
                     action="ignore",
                     category=SyntaxWarning,
-                    message="invalid escape sequence",
+                    message=r".*invalid escape sequence.*",
                 )
                 self.schema = yamale.make_schema(schema_path, parser="ruamel")
         elif schema_path == DEFAULT_SCHEMA:


### PR DESCRIPTION
The need to modify this originates because when users install python 3.14 or later and then try to run nac-validate tool they will see a bunch of warning messages even though they are not breaking anything in their schema or yaml files.

They will see something like this.
nac-validate --version
nac-validate, version 1.2.0

nac-validate -s schemas/schema.yaml -r validation/rules/ data/ .defaults/ -v DEBUG
INFO - Loading schema
<unknown>:1: SyntaxWarning: "\d" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\d"? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\d" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\d"? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\d" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\d"? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\." is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\."? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\d" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\d"? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\d" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\d"? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\d" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\d"? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\d" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\d"? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\[" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\["? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\." is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\."? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\-" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\-"? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\-" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\-"? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\[" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\["? A raw string is also an option.
<unknown>:1: SyntaxWarning: "\d" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\d"? A raw string is also an option.
… snip…
<unknown>:1: SyntaxWarning: "\[" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\["? A raw string is also an option.
INFO - Loading rules

The nac-validate tool includes a script called validator.py that already has a function that catches the warnings and ignores them. The reason why these warnings are caught with releases below 3.14 but not caught when using python 3.14 is because the warning message generated doesn't match what the function is expecting as a pattern.

Current script inside nac-validate is expecting the message to begin with:

message="invalid escape sequence"

As shown above, the warnings similarly begin with:

:1: SyntaxWarning: "\d" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\d"? A raw string is also an option.

After doing some testing I modified the pattern that the script is expecting to:

message=r".invalid escape sequence."

that way it matches that pattern anywhere in the message. After modifying that line please see on the image how execution went. I tested it with one validation rule error on purpose just to see if nac-validate it's working fine.

<img width="1383" height="676" alt="Screenshot 2026-03-10 at 5 08 36 p m" src="https://github.com/user-attachments/assets/6de8b6ae-05e0-40fb-a0e0-a6e15649748b" />

That would help people avoid those warning messages when using python 3.14 while executing nac-validate and continue to work normally.

